### PR TITLE
Remove dot symbol from hashtag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ exclude:
   - README.md
   - vendor
 google_analytics:
-hashtag: yarukinai.fm
+hashtag: yarukinaifm
 itunes_podcast_url: https://podcasts.apple.com/jp/podcast/yarukinai-fm/id1468116415
 keywords: yarukinai,kinpatsu,tetuo41
 language: ja


### PR DESCRIPTION
- ドット `.` はTwitterのハッシュタグには使えない（ドット以降がリンクにならない）ようなので削除しました。

![Screen Shot 2019-07-11 at 11 41 23](https://user-images.githubusercontent.com/1026842/61018174-d561eb00-a3d0-11e9-8c47-fdb5f7a41527.png)
